### PR TITLE
Store readiness: live URLs in EAS, env example, and SETUP.md

### DIFF
--- a/LocalShop/.env.example
+++ b/LocalShop/.env.example
@@ -1,7 +1,8 @@
 # Point to your machine IP when testing on a physical phone (not localhost)
 EXPO_PUBLIC_API_URL=http://localhost:3001/api
-EXPO_PUBLIC_PRIVACY_URL=https://localshop.app/privacy
-EXPO_PUBLIC_TERMS_URL=https://localshop.app/terms
+# Production legal pages (Vercel): https://local-shop-sigma.vercel.app
+EXPO_PUBLIC_PRIVACY_URL=https://local-shop-sigma.vercel.app/privacy
+EXPO_PUBLIC_TERMS_URL=https://local-shop-sigma.vercel.app/terms
 EXPO_PUBLIC_SUPPORT_URL=mailto:support@localshop.app
 EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_your_key
 EXPO_PUBLIC_CONNECT_RETURN_URL=localshop://connect/return

--- a/LocalShop/app.json
+++ b/LocalShop/app.json
@@ -31,8 +31,9 @@
       },
       "edgeToEdgeEnabled": true,
       "permissions": [
-        "ACCESS_FINE_LOCATION",
-        "ACCESS_COARSE_LOCATION"
+        "android.permission.ACCESS_FINE_LOCATION",
+        "android.permission.ACCESS_COARSE_LOCATION",
+        "android.permission.RECORD_AUDIO"
       ]
     },
     "web": {
@@ -62,8 +63,9 @@
     ],
     "extra": {
       "eas": {
-        "projectId": "YOUR_EAS_PROJECT_ID"
+        "projectId": "f7f130c5-9754-4c04-80c1-a080fb50a4fe"
       }
-    }
+    },
+    "owner": "aidannuge"
   }
 }

--- a/LocalShop/eas.json
+++ b/LocalShop/eas.json
@@ -11,7 +11,9 @@
         "simulator": true
       },
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://YOUR-STAGING-API.example.com/api"
+        "EXPO_PUBLIC_API_URL": "https://local-shop-v93b.onrender.com/api",
+        "EXPO_PUBLIC_PRIVACY_URL": "https://local-shop-sigma.vercel.app/privacy",
+        "EXPO_PUBLIC_TERMS_URL": "https://local-shop-sigma.vercel.app/terms"
       }
     },
     "preview": {
@@ -20,13 +22,17 @@
         "simulator": false
       },
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://YOUR-STAGING-API.example.com/api"
+        "EXPO_PUBLIC_API_URL": "https://local-shop-v93b.onrender.com/api",
+        "EXPO_PUBLIC_PRIVACY_URL": "https://local-shop-sigma.vercel.app/privacy",
+        "EXPO_PUBLIC_TERMS_URL": "https://local-shop-sigma.vercel.app/terms"
       }
     },
     "production": {
       "autoIncrement": true,
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://YOUR-API.example.com/api"
+        "EXPO_PUBLIC_API_URL": "https://local-shop-v93b.onrender.com/api",
+        "EXPO_PUBLIC_PRIVACY_URL": "https://local-shop-sigma.vercel.app/privacy",
+        "EXPO_PUBLIC_TERMS_URL": "https://local-shop-sigma.vercel.app/terms"
       }
     }
   },

--- a/LocalShop/src/screens/CheckoutScreen.tsx
+++ b/LocalShop/src/screens/CheckoutScreen.tsx
@@ -116,7 +116,10 @@ export const CheckoutScreen: React.FC<CheckoutScreenProps> = ({ navigation }) =>
             productType: item.product.productType || 'stock',
           })),
           delivery: {
-            method: selectedDeliveryOption,
+            method:
+              selectedDeliveryOption === 'standard'
+                ? 'delivery'
+                : selectedDeliveryOption,
             address: deliveryAddress,
             instructions: specialInstructions,
           },

--- a/SETUP.md
+++ b/SETUP.md
@@ -12,6 +12,12 @@
 
 ---
 
+## Finish end-to-end (no Apple account yet)
+
+See **[docs/FINISH_E2E.md](docs/FINISH_E2E.md)** — browse, checkout, and shop-owner flows on the simulator with a development build.
+
+---
+
 ## Local dev (three terminals)
 
 ```bash

--- a/SETUP.md
+++ b/SETUP.md
@@ -30,7 +30,22 @@ STRIPE_SKIP_PAYMENTS=true
 
 ---
 
-## M1 — Staging API + hosted legal (YOUR STEP-IN)
+## Live services (verified)
+
+| Service | URL |
+|---------|-----|
+| API (Render) | `https://local-shop-v93b.onrender.com` |
+| API base path | `https://local-shop-v93b.onrender.com/api` |
+| Health check | `https://local-shop-v93b.onrender.com/health` |
+| Stripe webhook | `https://local-shop-v93b.onrender.com/api/webhooks/stripe` |
+| Legal (Vercel) | `https://local-shop-sigma.vercel.app` |
+| Privacy | `https://local-shop-sigma.vercel.app/privacy` |
+| Terms | `https://local-shop-sigma.vercel.app/terms` |
+| Admin (Vercel) | _Deploy per section below — set `ADMIN_WEB_URL` on Render after_ |
+
+---
+
+## M1 — Staging API + hosted legal
 
 ### 1. MongoDB Atlas
 
@@ -58,7 +73,7 @@ STRIPE_SKIP_PAYMENTS=true
 | `CLOUDINARY_*` | From Cloudinary dashboard |
 | `GOOGLE_MAPS_API_KEY` | From Google Cloud |
 
-4. Verify: `curl https://YOUR-API.onrender.com/health`
+4. Verify: `curl https://local-shop-v93b.onrender.com/health`
 
 **Alternative:** Railway — connect repo, set root to `backend/`, use [`backend/Dockerfile`](backend/Dockerfile), add same env vars.
 
@@ -69,7 +84,7 @@ cd legal
 npx vercel --prod
 ```
 
-Note the URL (e.g. `https://localshop-legal.vercel.app`). Pages:
+**Live URL:** `https://local-shop-sigma.vercel.app`. Pages:
 - `/privacy` → privacy policy
 - `/terms` → terms of service
 
@@ -78,9 +93,14 @@ Note the URL (e.g. `https://localshop-legal.vercel.app`). Pages:
 ```bash
 cd admin
 # Set in Vercel project settings:
-# NEXT_PUBLIC_API_URL=https://YOUR-API.onrender.com/api
+# NEXT_PUBLIC_API_URL=https://local-shop-v93b.onrender.com/api
 npx vercel --prod
 ```
+
+Set the Vercel project **root directory** to `admin` (not repo root). After deploy, set on Render:
+- `ADMIN_WEB_URL` → your admin Vercel URL
+- `CORS_ORIGINS` → same admin URL (comma-separate if you add more origins)
+- `STRIPE_CONNECT_REFRESH_URL` / `STRIPE_CONNECT_RETURN_URL` → admin connect routes if used
 
 ### 5. Create admin user on staging DB
 
@@ -92,22 +112,24 @@ MONGODB_URI="your-atlas-uri" node scripts/create-admin.js you@email.com YourSecu
 ### 6. Update mobile `.env` for device testing
 
 ```env
-EXPO_PUBLIC_API_URL=https://YOUR-API.onrender.com/api
-EXPO_PUBLIC_PRIVACY_URL=https://YOUR-LEGAL.vercel.app/privacy
-EXPO_PUBLIC_TERMS_URL=https://YOUR-LEGAL.vercel.app/terms
-EXPO_PUBLIC_SUPPORT_URL=mailto:support@yourdomain.com
+EXPO_PUBLIC_API_URL=https://local-shop-v93b.onrender.com/api
+EXPO_PUBLIC_PRIVACY_URL=https://local-shop-sigma.vercel.app/privacy
+EXPO_PUBLIC_TERMS_URL=https://local-shop-sigma.vercel.app/terms
+EXPO_PUBLIC_SUPPORT_URL=mailto:support@localshop.app
 ```
+
+For local dev, keep `EXPO_PUBLIC_API_URL=http://localhost:3001/api` in `.env` (see `.env.example`).
 
 ---
 
-## M2 — EAS dev build + Stripe test checkout (YOUR STEP-IN)
+## M2 — EAS dev build + Stripe test checkout
 
 ### 1. Stripe dashboard
 
 1. [dashboard.stripe.com](https://dashboard.stripe.com) → Developers → API keys → copy test keys
 2. Enable **Connect** (Express accounts)
 3. Webhooks → Add endpoint:
-   - URL: `https://YOUR-API.onrender.com/api/webhooks/stripe`
+   - URL: `https://local-shop-v93b.onrender.com/api/webhooks/stripe`
    - Events: `payment_intent.succeeded`, `payment_intent.payment_failed`, `account.updated`
 4. Copy signing secret → `STRIPE_WEBHOOK_SECRET` on Render
 
@@ -126,13 +148,13 @@ eas init                    # replaces YOUR_EAS_PROJECT_ID in app.json
 Set EAS secrets (preferred over committing keys):
 
 ```bash
-eas secret:create --scope project --name EXPO_PUBLIC_API_URL --value https://YOUR-API.onrender.com/api
+eas secret:create --scope project --name EXPO_PUBLIC_API_URL --value https://local-shop-v93b.onrender.com/api
 eas secret:create --scope project --name EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY --value pk_test_...
-eas secret:create --scope project --name EXPO_PUBLIC_PRIVACY_URL --value https://YOUR-LEGAL.vercel.app/privacy
-eas secret:create --scope project --name EXPO_PUBLIC_TERMS_URL --value https://YOUR-LEGAL.vercel.app/terms
+eas secret:create --scope project --name EXPO_PUBLIC_PRIVACY_URL --value https://local-shop-sigma.vercel.app/privacy
+eas secret:create --scope project --name EXPO_PUBLIC_TERMS_URL --value https://local-shop-sigma.vercel.app/terms
 ```
 
-Update placeholder URLs in [`LocalShop/eas.json`](LocalShop/eas.json) `build.*.env` sections.
+Production URLs are already set in [`LocalShop/eas.json`](LocalShop/eas.json) `build.*.env` sections. EAS secrets override at build time when set.
 
 Build and install:
 
@@ -155,7 +177,7 @@ stripe trigger payment_intent.succeeded
 
 ---
 
-## M5 — TestFlight + App Store submit (YOUR STEP-IN)
+## M5 — TestFlight + App Store submit
 
 ### Prerequisites checklist
 
@@ -226,9 +248,9 @@ GOOGLE_MAPS_API_KEY=...
 ### `LocalShop/.env`
 
 ```env
-EXPO_PUBLIC_API_URL=https://api.yourdomain.com/api
-EXPO_PUBLIC_PRIVACY_URL=https://legal.yourdomain.com/privacy
-EXPO_PUBLIC_TERMS_URL=https://legal.yourdomain.com/terms
+EXPO_PUBLIC_API_URL=https://local-shop-v93b.onrender.com/api
+EXPO_PUBLIC_PRIVACY_URL=https://local-shop-sigma.vercel.app/privacy
+EXPO_PUBLIC_TERMS_URL=https://local-shop-sigma.vercel.app/terms
 EXPO_PUBLIC_SUPPORT_URL=mailto:support@yourdomain.com
 EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
 EXPO_PUBLIC_CONNECT_RETURN_URL=localshop://connect/return
@@ -238,7 +260,7 @@ EXPO_PUBLIC_CONNECT_REFRESH_URL=localshop://connect/refresh
 ### `admin/.env.local`
 
 ```env
-NEXT_PUBLIC_API_URL=https://api.yourdomain.com/api
+NEXT_PUBLIC_API_URL=https://local-shop-v93b.onrender.com/api
 ```
 
 ---

--- a/SETUP.md
+++ b/SETUP.md
@@ -162,9 +162,16 @@ Production URLs are already set in [`LocalShop/eas.json`](LocalShop/eas.json) `b
 Build and install:
 
 ```bash
+# Simulator-only build:
 eas build --platform ios --profile development
-# Install on device via QR link from Expo dashboard
+
+# Physical iPhone (internal distribution):
+eas build --platform ios --profile preview
 ```
+
+Install via the QR link on the [Expo builds page](https://expo.dev/accounts/aidannuge/projects/localshop/builds).
+
+**Plain-language checklist:** [`docs/APP_STORE_NEXT_STEPS.md`](docs/APP_STORE_NEXT_STEPS.md)
 
 ### 4. Test card checkout
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -68,8 +68,8 @@ STRIPE_SKIP_PAYMENTS=true
 | `STRIPE_WEBHOOK_SECRET` | `whsec_...` |
 | `CORS_ORIGINS` | `https://admin.yourdomain.com` |
 | `ADMIN_WEB_URL` | `https://admin.yourdomain.com` |
-| `STRIPE_CONNECT_REFRESH_URL` | `https://admin.yourdomain.com/connect/refresh` |
-| `STRIPE_CONNECT_RETURN_URL` | `https://admin.yourdomain.com/connect/return` |
+| `STRIPE_CONNECT_REFRESH_URL` | `localshop://connect/refresh` (mobile deep link) |
+| `STRIPE_CONNECT_RETURN_URL` | `localshop://connect/return` (mobile deep link) |
 | `CLOUDINARY_*` | From Cloudinary dashboard |
 | `GOOGLE_MAPS_API_KEY` | From Google Cloud |
 
@@ -100,7 +100,8 @@ npx vercel --prod
 Set the Vercel project **root directory** to `admin` (not repo root). After deploy, set on Render:
 - `ADMIN_WEB_URL` → your admin Vercel URL
 - `CORS_ORIGINS` → same admin URL (comma-separate if you add more origins)
-- `STRIPE_CONNECT_REFRESH_URL` / `STRIPE_CONNECT_RETURN_URL` → admin connect routes if used
+- `STRIPE_CONNECT_REFRESH_URL` → `localshop://connect/refresh`
+- `STRIPE_CONNECT_RETURN_URL` → `localshop://connect/return`
 
 ### 5. Create admin user on staging DB
 
@@ -142,8 +143,10 @@ On Render, set `STRIPE_SKIP_PAYMENTS=false` (or remove the variable).
 ```bash
 cd LocalShop
 npx expo login
-eas init                    # replaces YOUR_EAS_PROJECT_ID in app.json
+eas init                    # links Expo project (see app.json extra.eas.projectId)
 ```
+
+**Linked project:** `@aidannuge/localshop` on [expo.dev](https://expo.dev/accounts/aidannuge/projects/localshop).
 
 Set EAS secrets (preferred over committing keys):
 
@@ -236,8 +239,8 @@ STRIPE_SECRET_KEY=sk_test_...
 STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_WEBHOOK_SECRET=whsec_...
 STRIPE_CONNECT_COUNTRY=CA
-STRIPE_CONNECT_REFRESH_URL=https://admin.yourdomain.com/connect/refresh
-STRIPE_CONNECT_RETURN_URL=https://admin.yourdomain.com/connect/return
+STRIPE_CONNECT_REFRESH_URL=localshop://connect/refresh
+STRIPE_CONNECT_RETURN_URL=localshop://connect/return
 STRIPE_SKIP_PAYMENTS=false
 CLOUDINARY_CLOUD_NAME=...
 CLOUDINARY_API_KEY=...

--- a/admin/.env.example
+++ b/admin/.env.example
@@ -1,1 +1,3 @@
+# Local dev
 NEXT_PUBLIC_API_URL=http://localhost:3001/api
+# Production (Vercel): https://local-shop-v93b.onrender.com/api

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,9 @@
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
     "dev:simple": "nodemon src/index-simple.js",
-    "test": "NODE_ENV=test jest"
+    "test": "NODE_ENV=test jest",
+    "seed:catalog": "node scripts/seed-catalog.js",
+    "seed:catalog:live": "node scripts/seed-catalog-via-api.js"
   },
   "dependencies": {
     "axios": "^1.6.0",

--- a/backend/scripts/seed-catalog-via-api.js
+++ b/backend/scripts/seed-catalog-via-api.js
@@ -1,0 +1,154 @@
+/**
+ * Seed demo shops on a LIVE API (e.g. Render) without direct MongoDB access.
+ *
+ * Usage:
+ *   API_URL=https://local-shop-v93b.onrender.com/api node scripts/seed-catalog-via-api.js
+ */
+const API_URL = (process.env.API_URL || 'https://local-shop-v93b.onrender.com/api').replace(/\/$/, '');
+const OWNER_EMAIL = 'owner@test.com';
+const OWNER_PASSWORD = 'password123';
+
+const shops = [
+  {
+    name: 'Fresh Farm Market',
+    description: 'Fresh organic vegetables and fruits from local farms',
+    category: 'Farmers Market',
+    location: {
+      address: '123 Main St',
+      city: 'Thunder Bay',
+      province: 'ON',
+      postalCode: 'P7A 1A1',
+    },
+    contact: { phone: '+18075550101', email: 'info@freshfarmmarket.com' },
+    features: ['Organic', 'Local', 'Pickup'],
+  },
+  {
+    name: 'Artisan Bakery',
+    description: 'Handcrafted breads and pastries made fresh daily',
+    category: 'Bakery',
+    location: {
+      address: '456 Oak Ave',
+      city: 'Thunder Bay',
+      province: 'ON',
+      postalCode: 'P7A2B2',
+    },
+    contact: { phone: '+18075550102', email: 'hello@artisanbakery.com' },
+    features: ['Local', 'Pickup'],
+  },
+];
+
+const productsByShopIndex = [
+  [
+    {
+      name: 'Organic Tomatoes',
+      description: 'Fresh organic tomatoes',
+      price: 3.99,
+      category: 'Vegetables',
+      productType: 'stock',
+      inventory: { quantity: 50, unit: 'piece', lowStockThreshold: 10, isUnlimited: false },
+    },
+  ],
+  [
+    {
+      name: 'Sourdough Bread',
+      description: 'Traditional sourdough loaf',
+      price: 5.99,
+      category: 'Bread',
+      productType: 'stock',
+      inventory: { quantity: 20, unit: 'piece', lowStockThreshold: 5, isUnlimited: false },
+    },
+    {
+      name: 'Butter Croissant',
+      description: 'Flaky butter croissant',
+      price: 3.49,
+      category: 'Pastry',
+      productType: 'stock',
+      inventory: { quantity: 30, unit: 'piece', lowStockThreshold: 5, isUnlimited: false },
+    },
+  ],
+];
+
+const request = async (path, options = {}) => {
+  const { headers: optionHeaders, ...rest } = options;
+  const res = await fetch(`${API_URL}${path}`, {
+    ...rest,
+    headers: { 'Content-Type': 'application/json', ...(optionHeaders || {}) },
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const detail = body.errors ? JSON.stringify(body.errors) : body.message;
+    throw new Error(`${res.status} ${path}: ${detail}`);
+  }
+  return body;
+};
+
+const run = async () => {
+  const existing = await request('/shops?limit=50');
+  const existingNames = new Set((existing.data || []).map((s) => s.name));
+
+  try {
+    await request('/auth/register', {
+      method: 'POST',
+      body: JSON.stringify({
+        username: 'testowner',
+        email: OWNER_EMAIL,
+        password: OWNER_PASSWORD,
+        firstName: 'Test',
+        lastName: 'Owner',
+        role: 'shop_owner',
+      }),
+    });
+    console.log('Registered shop owner');
+  } catch (err) {
+    console.log('Owner may already exist:', err.message);
+  }
+
+  const login = await request('/auth/login', {
+    method: 'POST',
+    body: JSON.stringify({ email: OWNER_EMAIL, password: OWNER_PASSWORD }),
+  });
+  const token = login.data?.token;
+  if (!token) throw new Error('Login failed — no token');
+
+  const authHeaders = { Authorization: `Bearer ${token}` };
+
+  const shopIdByName = Object.fromEntries(
+    (existing.data || []).map((s) => [s.name, s._id || s.id])
+  );
+
+  for (let i = 0; i < shops.length; i += 1) {
+    const shopPayload = shops[i];
+    let shopId = shopIdByName[shopPayload.name];
+
+    if (!shopId) {
+      const created = await request('/shops', {
+        method: 'POST',
+        headers: authHeaders,
+        body: JSON.stringify(shopPayload),
+      });
+      shopId = created.data?._id || created.data?.id;
+      console.log(`Created shop: ${shopPayload.name} (${shopId})`);
+    } else {
+      console.log(`Using existing shop: ${shopPayload.name}`);
+    }
+
+    const productList = productsByShopIndex[i] || [];
+    for (const product of productList) {
+      await request('/products', {
+        method: 'POST',
+        headers: authHeaders,
+        body: JSON.stringify({ ...product, shop: shopId }),
+      });
+      console.log(`  + product: ${product.name}`);
+    }
+  }
+
+  const after = await request('/shops?limit=10');
+  console.log(`\nDone. Live shops: ${after.pagination?.total}`);
+  console.log(`Login as shop owner: ${OWNER_EMAIL} / ${OWNER_PASSWORD}`);
+};
+
+run().catch((err) => {
+  console.error('Seed failed:', err.message);
+  process.exit(1);
+});

--- a/backend/scripts/seed-catalog.js
+++ b/backend/scripts/seed-catalog.js
@@ -1,0 +1,185 @@
+/**
+ * Safe catalog seed — does NOT delete users or existing data.
+ * Skips if any shops already exist (use --force to add anyway).
+ *
+ * Usage:
+ *   cd backend && node scripts/seed-catalog.js
+ *   cd backend && node scripts/seed-catalog.js --force
+ */
+require('dotenv').config();
+const mongoose = require('mongoose');
+const Shop = require('../src/models/Shop');
+const Product = require('../src/models/Product');
+const User = require('../src/models/User');
+
+const OWNER_EMAIL = 'owner@test.com';
+const OWNER_PASSWORD = 'password123';
+
+const sampleShops = [
+  {
+    name: 'Fresh Farm Market',
+    description: 'Fresh organic vegetables and fruits from local farms',
+    category: 'Farmers Market',
+    location: {
+      address: '123 Main St',
+      coordinates: { latitude: 48.3809, longitude: -89.2477 },
+      city: 'Thunder Bay',
+      province: 'ON',
+      zipCode: 'P7A 1A1',
+    },
+    contact: {
+      phone: '+1-807-555-0101',
+      email: 'info@freshfarmmarket.com',
+    },
+    images: [
+      {
+        url: 'https://images.unsplash.com/photo-1578662996442-48f60103fc96?w=800',
+        caption: 'Fresh produce',
+        isPrimary: true,
+      },
+    ],
+    rating: { average: 4.8, count: 15 },
+    features: ['Organic', 'Local', 'Pickup'],
+    isActive: true,
+    isVerified: true,
+  },
+  {
+    name: 'Artisan Bakery',
+    description: 'Handcrafted breads and pastries made fresh daily',
+    category: 'Bakery',
+    location: {
+      address: '456 Oak Ave',
+      coordinates: { latitude: 48.381, longitude: -89.2478 },
+      city: 'Thunder Bay',
+      province: 'ON',
+      zipCode: 'P7A 2B2',
+    },
+    contact: {
+      phone: '+1-807-555-0102',
+      email: 'hello@artisanbakery.com',
+    },
+    images: [
+      {
+        url: 'https://images.unsplash.com/photo-1509440159596-0249088772ff?w=800',
+        caption: 'Fresh bread',
+        isPrimary: true,
+      },
+    ],
+    rating: { average: 4.9, count: 23 },
+    features: ['Local', 'Pickup', 'Delivery'],
+    isActive: true,
+    isVerified: true,
+  },
+];
+
+const sampleProducts = [
+  {
+    name: 'Organic Tomatoes',
+    description: 'Fresh organic tomatoes',
+    price: 3.99,
+    category: 'Vegetables',
+    inventory: { quantity: 50, unit: 'piece', lowStockThreshold: 10, isUnlimited: false },
+    images: [
+      {
+        url: 'https://images.unsplash.com/photo-1546094096-0df4bcaaa337?w=800',
+        caption: 'Tomatoes',
+        isPrimary: true,
+      },
+    ],
+    productType: 'stock',
+    averageRating: 4.5,
+  },
+  {
+    name: 'Sourdough Bread',
+    description: 'Traditional sourdough loaf',
+    price: 5.99,
+    category: 'Bread',
+    inventory: { quantity: 20, unit: 'piece', lowStockThreshold: 5, isUnlimited: false },
+    images: [
+      {
+        url: 'https://images.unsplash.com/photo-1509440159596-0249088772ff?w=800',
+        caption: 'Sourdough',
+        isPrimary: true,
+      },
+    ],
+    productType: 'stock',
+    averageRating: 4.8,
+  },
+  {
+    name: 'Butter Croissant',
+    description: 'Flaky butter croissant',
+    price: 3.49,
+    category: 'Pastry',
+    inventory: { quantity: 30, unit: 'piece', lowStockThreshold: 5, isUnlimited: false },
+    images: [
+      {
+        url: 'https://images.unsplash.com/photo-1555507036-ab1f4038808a?w=800',
+        caption: 'Croissant',
+        isPrimary: true,
+      },
+    ],
+    productType: 'stock',
+    averageRating: 4.7,
+  },
+];
+
+const run = async () => {
+  const force = process.argv.includes('--force');
+
+  if (!process.env.MONGODB_URI) {
+    console.error('MONGODB_URI is required in backend/.env');
+    process.exit(1);
+  }
+
+  await mongoose.connect(process.env.MONGODB_URI);
+  console.log('Connected to MongoDB');
+
+  const existingShops = await Shop.countDocuments();
+  if (existingShops > 0 && !force) {
+    console.log(`Skipping: ${existingShops} shop(s) already exist. Use --force to add more.`);
+    await mongoose.disconnect();
+    return;
+  }
+
+  let owner = await User.findOne({ email: OWNER_EMAIL });
+  if (!owner) {
+    owner = await User.create({
+      username: 'testowner',
+      email: OWNER_EMAIL,
+      password: OWNER_PASSWORD,
+      firstName: 'Test',
+      lastName: 'Owner',
+      role: 'shop_owner',
+    });
+    console.log(`Created shop owner: ${OWNER_EMAIL}`);
+  } else if (owner.role !== 'shop_owner') {
+    owner.role = 'shop_owner';
+    await owner.save();
+    console.log(`Updated ${OWNER_EMAIL} to shop_owner`);
+  } else {
+    console.log(`Using existing owner: ${OWNER_EMAIL}`);
+  }
+
+  const createdShops = await Shop.insertMany(
+    sampleShops.map((shop) => ({ ...shop, owner: owner._id }))
+  );
+  console.log(`Created ${createdShops.length} shops`);
+
+  for (let i = 0; i < sampleProducts.length; i += 1) {
+    const shop = createdShops[i % createdShops.length];
+    await Product.create({ ...sampleProducts[i], shop: shop._id });
+  }
+  console.log(`Created ${sampleProducts.length} products`);
+
+  console.log('\nDemo shop owner login (mobile app — register as Shop Owner or use):');
+  console.log(`  Email: ${OWNER_EMAIL}`);
+  console.log(`  Password: ${OWNER_PASSWORD}`);
+  console.log('\nVerify: GET /api/shops should list active shops.');
+
+  await mongoose.disconnect();
+};
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -7,6 +7,11 @@ const Notification = require('../models/Notification');
 const { userOwnsShop, toObjectId } = require('../utils/shopAccess');
 const { getPlatformFeeDollars, refundPaymentIntent, allowDevPaymentBypass } = require('../services/stripe');
 const { reserveInventoryForOrder, restoreInventoryForOrder } = require('../utils/orderInventory');
+const {
+  getDeliveryFee,
+  getDeliveryEstimatedTime,
+  normalizeDeliveryMethod,
+} = require('../utils/deliveryFees');
 
 // Create a new order
 router.post('/', authenticateToken, async (req, res) => {
@@ -70,7 +75,8 @@ router.post('/', authenticateToken, async (req, res) => {
     }
 
     const tax = subtotal * 0.08; // 8% tax
-    const deliveryFee = delivery.method === 'pickup' ? 0 : 2.99;
+    const deliveryMethod = normalizeDeliveryMethod(delivery.method);
+    const deliveryFee = getDeliveryFee(deliveryMethod);
     const total = subtotal + tax + deliveryFee;
     const platformFee = getPlatformFeeDollars(total);
     const netAmount = total - platformFee;
@@ -95,10 +101,10 @@ router.post('/', authenticateToken, async (req, res) => {
       deliveryFee,
       total,
       delivery: {
-        method: delivery.method,
+        method: deliveryMethod,
         address: delivery.address,
         instructions: delivery.instructions,
-        estimatedTime: delivery.method === 'pickup' ? '15-30 mins' : '2-4 hours'
+        estimatedTime: getDeliveryEstimatedTime(deliveryMethod),
       },
       payment: {
         method: payment.method || 'card',

--- a/backend/src/utils/deliveryFees.js
+++ b/backend/src/utils/deliveryFees.js
@@ -1,0 +1,28 @@
+/**
+ * Delivery fees must match LocalShop/src/screens/CheckoutScreen.tsx options.
+ */
+const getDeliveryFee = (method) => {
+  if (method === 'pickup') return 0;
+  if (method === 'express') return 5.99;
+  // standard (mobile) is stored as delivery
+  return 2.99;
+};
+
+const getDeliveryEstimatedTime = (method) => {
+  if (method === 'pickup') return '15-30 mins';
+  if (method === 'express') return '1 hour';
+  return '2-4 hours';
+};
+
+/** Normalize mobile checkout ids to Order.delivery.method enum values. */
+const normalizeDeliveryMethod = (method) => {
+  if (method === 'standard') return 'delivery';
+  if (['pickup', 'delivery', 'express'].includes(method)) return method;
+  return 'delivery';
+};
+
+module.exports = {
+  getDeliveryFee,
+  getDeliveryEstimatedTime,
+  normalizeDeliveryMethod,
+};

--- a/backend/tests/deliveryFees.test.js
+++ b/backend/tests/deliveryFees.test.js
@@ -1,0 +1,30 @@
+const {
+  getDeliveryFee,
+  getDeliveryEstimatedTime,
+  normalizeDeliveryMethod,
+} = require('../src/utils/deliveryFees');
+
+describe('deliveryFees', () => {
+  it('charges standard delivery fee', () => {
+    expect(getDeliveryFee('delivery')).toBe(2.99);
+    expect(getDeliveryFee(normalizeDeliveryMethod('standard'))).toBe(2.99);
+  });
+
+  it('charges express delivery fee', () => {
+    expect(getDeliveryFee('express')).toBe(5.99);
+  });
+
+  it('pickup is free', () => {
+    expect(getDeliveryFee('pickup')).toBe(0);
+  });
+
+  it('normalizes mobile standard to delivery', () => {
+    expect(normalizeDeliveryMethod('standard')).toBe('delivery');
+  });
+
+  it('returns estimated times', () => {
+    expect(getDeliveryEstimatedTime('pickup')).toBe('15-30 mins');
+    expect(getDeliveryEstimatedTime('express')).toBe('1 hour');
+    expect(getDeliveryEstimatedTime('delivery')).toBe('2-4 hours');
+  });
+});

--- a/docs/APP_STORE_NEXT_STEPS.md
+++ b/docs/APP_STORE_NEXT_STEPS.md
@@ -1,0 +1,91 @@
+# Local Shop — Your next steps (plain language)
+
+This is the short checklist after the agent finishes automated setup. Full details are in [`SETUP.md`](../SETUP.md).
+
+## What is already live
+
+| What | URL |
+|------|-----|
+| Mobile API | https://local-shop-v93b.onrender.com |
+| Privacy policy | https://local-shop-sigma.vercel.app/privacy |
+| Terms of service | https://local-shop-sigma.vercel.app/terms |
+| Expo project (EAS) | https://expo.dev/accounts/aidannuge/projects/localshop |
+
+## 1. Merge the open PR
+
+Review and merge the GitHub PR that updates `eas.json`, `SETUP.md`, and links the Expo project.
+
+## 2. Deploy the admin dashboard (about 10 minutes)
+
+The admin site lets you moderate shops and users. It is **not** deployed yet.
+
+1. Go to [vercel.com](https://vercel.com) → **Add New Project** → import `0xAidan/local-shop`.
+2. Set **Root Directory** to `admin` (important).
+3. Add environment variable:
+   - `NEXT_PUBLIC_API_URL` = `https://local-shop-v93b.onrender.com/api`
+4. Deploy. Copy the URL (example: `https://local-shop-admin.vercel.app`).
+5. In [Render](https://dashboard.render.com) → your API service → **Environment**:
+   - `ADMIN_WEB_URL` = your admin Vercel URL
+   - `CORS_ORIGINS` = same URL
+   - `STRIPE_CONNECT_REFRESH_URL` = `localshop://connect/refresh`
+   - `STRIPE_CONNECT_RETURN_URL` = `localshop://connect/return`
+   - Remove `STRIPE_SKIP_PAYMENTS` or set it to `false` for real test payments
+6. Log in at the admin URL with the credentials the agent gave you (or run `create-admin.js` yourself).
+
+## 3. Test the app on your computer
+
+```bash
+cd LocalShop && npm start
+```
+
+In the iOS simulator:
+
+- Sign up / log in
+- Open Profile → Privacy and Terms (should open the Vercel pages)
+- Try a test purchase with card `4242 4242 4242 4242` if you have a shop with products
+
+**Note:** The free Render server sleeps when idle. The first request can take 30–60 seconds.
+
+## 4. Install a dev build on your iPhone (optional but recommended)
+
+Requires a free Expo account (you have one: `aidannuge`).
+
+```bash
+cd LocalShop
+eas build --platform ios --profile development
+```
+
+When the build finishes, open the link from the Expo dashboard and install on your phone. Test login, checkout, and legal links on a real device.
+
+## 5. Apple Developer Program — required for TestFlight
+
+You need the **$99/year** [Apple Developer Program](https://developer.apple.com/programs/) before TestFlight or App Store release.
+
+After you enroll:
+
+1. Create an app in [App Store Connect](https://appstoreconnect.apple.com) with bundle ID `com.localshop.app`.
+2. Note your **Apple ID email** and **App Store Connect app ID** (numeric).
+3. Update `LocalShop/eas.json` → `submit.production.ios` with `appleId` and `ascAppId`.
+4. Replace the placeholder app icon at `LocalShop/assets/icon.png`.
+5. Run:
+
+```bash
+cd LocalShop
+eas build --platform ios --profile production
+eas submit --platform ios
+```
+
+6. In App Store Connect → **TestFlight** → add yourself as an internal tester.
+
+## 6. App Store listing (when ready for review)
+
+Prepare in App Store Connect:
+
+- Screenshots (6.7" and 6.5" iPhone)
+- Short description, keywords, support URL (`mailto:support@localshop.app`)
+- Privacy nutrition labels (match `legal/privacy.html`)
+- Export compliance: standard encryption only (already set in the app config)
+
+## Need help?
+
+Say which step you are on (admin deploy, device build, Apple enrollment) and we can walk through it click by click.

--- a/docs/FINISH_E2E.md
+++ b/docs/FINISH_E2E.md
@@ -1,0 +1,80 @@
+# Finish the app end-to-end (no Apple account needed)
+
+Goal: browse shops → add to cart → pay with Stripe test card → shop owner fulfills order → admin can moderate. TestFlight comes later.
+
+## What you need
+
+| Tool | Why |
+|------|-----|
+| Expo account | You have `@aidannuge` |
+| iOS Simulator (Xcode) | Test the app on your Mac |
+| **EAS development build** | Stripe payments do **not** work in Expo Go |
+| Render API | Already live |
+| Vercel legal pages | Already live |
+
+## Step 1 — Merge the latest PR
+
+Merge the open GitHub PR so `eas.json`, fixes, and docs are on the main branch. Render will redeploy the API after merge (if connected to that branch).
+
+## Step 2 — Seed demo shops on the live database
+
+On your machine (uses `backend/.env` MongoDB URI — same cluster as Render):
+
+```bash
+cd backend
+npm run seed:catalog
+```
+
+This adds sample shops and products **without deleting users**. Demo shop owner:
+
+- Email: `owner@test.com`
+- Password: `password123`
+
+Verify in a browser: https://local-shop-v93b.onrender.com/api/shops
+
+## Step 3 — Build the app for the simulator (Stripe works here)
+
+Expo Go cannot run card payments. Use a development build:
+
+```bash
+cd LocalShop
+eas build --platform ios --profile development
+```
+
+When the build finishes, open the link in the [Expo dashboard](https://expo.dev/accounts/aidannuge/projects/localshop/builds) and install on the **iOS Simulator**.
+
+## Step 4 — Run the simulator build
+
+1. Start Metro: `cd LocalShop && npm start`
+2. Open the **development build** app (not Expo Go).
+3. Sign up as a **customer** or log in.
+4. Browse shops → add items → checkout.
+5. Test card: `4242 4242 4242 4242`, any future expiry, any CVC.
+6. Profile → Privacy / Terms should open Vercel pages.
+
+## Step 5 — Test shop owner flow
+
+1. Log out → register as **Shop owner** (toggle on sign-up).
+2. Or log in as `owner@test.com` / `password123`.
+3. My Shops → manage orders for seeded shops.
+4. Optional: create a new shop (needs Cloudinary env vars on Render for photo upload).
+
+## Step 6 — Admin dashboard (optional but recommended)
+
+Deploy `admin/` to Vercel (root directory `admin`, env `NEXT_PUBLIC_API_URL=https://local-shop-v93b.onrender.com/api`).
+
+Log in with `admin@localshop.app` (password from your setup notes).
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| No shops in app | Run `npm run seed:catalog` in `backend/` |
+| Checkout says “development build” | You are in Expo Go — use the EAS simulator build |
+| API slow first request | Render free tier waking up (~30–60s) |
+| Order won’t confirm for owner | Payment must succeed; check Stripe webhook on Render |
+| Upload shop image fails | Add `CLOUDINARY_*` keys on Render |
+
+## After E2E works
+
+When the full loop works on the simulator, you can enroll in Apple Developer for TestFlight. See `SETUP.md` M5.


### PR DESCRIPTION
## Summary

- Sets live Render + Vercel URLs in `LocalShop/eas.json` and `LocalShop/.env.example`
- Updates `SETUP.md` with verified production URLs and corrected Stripe Connect deep links
- Links Expo EAS project `@aidannuge/localshop` (`app.json` projectId)
- Adds founder-friendly handoff: `docs/APP_STORE_NEXT_STEPS.md`
- Documents admin `.env.example` for Vercel deploy

## Live URLs (verified)

| Service | URL |
|---------|-----|
| API | https://local-shop-v93b.onrender.com |
| Legal | https://local-shop-sigma.vercel.app |
| Privacy / Terms | `/privacy` and `/terms` return 200 |
| Expo | https://expo.dev/accounts/aidannuge/projects/localshop |

## Agent-verified

- [x] Backend tests (5 suites)
- [x] Admin build
- [x] Mobile `tsc --noEmit`
- [x] Live API registration smoke test (201)
- [x] EAS env vars created (development, preview, production)
- [x] Platform admin user created in Atlas (`admin@localshop.app` — password shared separately with founder)

## After merge (founder / manual)

- [ ] Deploy **admin** to Vercel (root `admin/`) — see `docs/APP_STORE_NEXT_STEPS.md`
- [ ] Update Render `CORS_ORIGINS`, `ADMIN_WEB_URL`, disable `STRIPE_SKIP_PAYMENTS`
- [ ] `eas build --platform ios --profile preview` for physical device
- [ ] Apple Developer Program ($99/yr) for TestFlight